### PR TITLE
Add Support for Monorepos

### DIFF
--- a/src/LintChecker.cs
+++ b/src/LintChecker.cs
@@ -224,8 +224,10 @@ namespace FSharpLintVs
                         Document.FilePath,
                         ProjectInfo.Project.FileName,
                         ProjectInfo.Solution.FileName,
+                        Directory.GetParent(ProjectInfo.Solution.FileName).FullName
                     }
                     .Select(Path.GetDirectoryName)
+                    .Where(dir => !string.IsNullOrEmpty(dir))
                     .Select(dir => Path.Combine(dir, "fsharplint.json"))
                     .Where(File.Exists)
                     .Select(Lint.ConfigurationParam.NewFromFile)


### PR DESCRIPTION
For your consideration:

I have a case where I am using a monorepo for several F# projects, and I would like to be able to hold one `fsharplint.json` file in the root directory of the repo, and have each solution reference it

Example file hierarchy:

```
.
+-- fsharplint.json
+-- project1
|   +-- project1.sln
+-- project2/
|   +-- project2.sln
```

In order to accomplish this, I:

- Added an extra file path to the Configuration search paths
- Added a filter to prevent null paths if a solution is in the root directory
